### PR TITLE
Fix non-default filepath assignment in mem_import()

### DIFF
--- a/R/meetup_import.R
+++ b/R/meetup_import.R
@@ -42,11 +42,11 @@
 meetup_import <- function(file = NULL, format = "%d-%b-%y", ...) {
 
 if(is.null(file) == TRUE) {
-        
-file_path <- paste0(getwd(), "/data-raw/meetup/", list.files("data-raw/meetup", pattern = ".csv$"))
-
+        file_path <- paste0(getwd(), "/data-raw/meetup/", list.files("data-raw/meetup", pattern = ".csv$"))
+} else {
+        file_path <- file
 }
-        
+
 member_list <- read.csv(file = file_path, stringsAsFactors=FALSE, ...)
 
 ####################


### PR DESCRIPTION
Slight adjustment needed for optional _file_ parameter in `mem_import()`. Right now, if users set a non-NULL value to _file_, _file_path_ is never assigned and hence throws error at `read.csv()` line. This PR assigns the non-default _file_path_ in `else` condition equal to _file_ parameter.